### PR TITLE
Add `total_delay` to handler arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ end
 ### Handlers
 
 `with_retries` allows you to pass a custom handler that will be called each time before the block is retried.
-The handler will be called with two arguments: `exception` (the rescued exception) and `attempt_number` (the
-number of attempts that have been made thus far).
+The handler will be called with three arguments: `exception` (the rescued exception), `attempt_number` (the
+number of attempts that have been made thus far), and `total_delay` (the number of seconds since the start
+of the time the block was first attempted, including all retries).
 
 ``` ruby
-handler = Proc.new do |exception, attempt_number|
-  puts "Handler saw a #{exception.class}; retry attempt #{attempt_number}"
+handler = Proc.new do |exception, attempt_number, total_delay|
+  puts "Handler saw a #{exception.class}; retry attempt #{attempt_number}; #{total_delay} seconds have passed."
 end
 with_retries(:max_tries => 5, :handler => handler, :rescue => [RuntimeError, ZeroDivisionError]) do |attempt|
   (1 / 0) if attempt == 3
@@ -61,13 +62,13 @@ with_retries(:max_tries => 5, :handler => handler, :rescue => [RuntimeError, Zer
 end
 ```
 
-This will print:
+This will print something like:
 
 ```
-Handler saw a RuntimeError; retry attempt 1
-Handler saw a RuntimeError; retry attempt 2
-Handler saw a ZeroDivisionError; retry attempt 3
-Handler saw a RuntimeError; retry attempt 4
+Handler saw a RuntimeError; retry attempt 1; 2.9e-05 seconds have passed.
+Handler saw a RuntimeError; retry attempt 2; 0.501176 seconds have passed.
+Handler saw a ZeroDivisionError; retry attempt 3; 1.129921 seconds have passed.
+Handler saw a RuntimeError; retry attempt 4; 1.886828 seconds have passed.
 ```
 
 ### Delay parameters

--- a/lib/retries.rb
+++ b/lib/retries.rb
@@ -40,12 +40,13 @@ module Kernel
 
     # Let's do this thing
     attempts = 0
+    start_time = Time.now
     begin
       attempts += 1
       return block.call(attempts)
     rescue *exception_types_to_rescue => exception
       raise exception if attempts >= max_tries
-      handler.call(exception, attempts) if handler
+      handler.call(exception, attempts, Time.now - start_time) if handler
       # Don't sleep at all if sleeping is disabled (used in testing).
       if Retries.sleep_enabled
         # The sleep time is an exponentially-increasing function of base_sleep_seconds. But, it never exceeds

--- a/lib/retries.rb
+++ b/lib/retries.rb
@@ -18,7 +18,8 @@ module Kernel
   # @option options [Float] :base_sleep_seconds (0.5) The starting delay between retries.
   # @option options [Float] :max_sleep_seconds (1.0) The maximum to which to expand the delay between retries.
   # @option options [Proc] :handler (nil) If not `nil`, a `Proc` that will be called for each retry. It will be
-  #         passed two arguments, `exception` (the rescued exception) and `attempt_number`.
+  #         passed three arguments, `exception` (the rescued exception), `attempt_number`,
+  #         and `total_delay` (seconds since start of first attempt).
   # @option options [Exception, <Exception>] :rescue (StandardError) This may be a specific exception class to
   #         rescue or an array of classes.
   # @yield [attempt_number] The (required) block to be executed, which is passed the attempt number as a

--- a/test/retries_test.rb
+++ b/test/retries_test.rb
@@ -66,8 +66,8 @@ class RetriesTest < Scope::TestCase
         assert_equal exception_handler_run_times, attempt_number
         assert exception.is_a?(CustomErrorA)
       end
-      with_retries(:max_tries => 4, :base_sleep_seconds => 0, :max_sleep_seconds => 0, :handler => handler,
-                   :rescue => CustomErrorA) do
+      with_retries(:max_tries => 4, :base_sleep_seconds => 0, :max_sleep_seconds => 0, 
+                   :handler => handler, :rescue => CustomErrorA) do
         tries += 1
         raise CustomErrorA.new if tries < 4
       end
@@ -80,17 +80,14 @@ class RetriesTest < Scope::TestCase
       tries = 0
       start_time = Time.now
       handler = Proc.new do |exception, attempt_number, total_delay|
-        exception_handler_run_times += 1
         # Check that the handler is passed the proper total delay time
-        assert(total_delay - (Time.now - start_time) <= 0.01, "total_delay=#{total_delay}, should be closer to #{Time.now - start_time}")
+        assert_in_delta(total_delay, Time.now - start_time, 0.01)
       end
-      with_retries(:max_tries => 4, :base_sleep_seconds => 0.1, :max_sleep_seconds => 0.5, :handler => handler,
-                   :rescue => CustomErrorA) do
+      with_retries(:max_tries => 3, :base_sleep_seconds => 0.05, :max_sleep_seconds => 0.25,
+                   :handler => handler, :rescue => CustomErrorA) do
         tries += 1
-        raise CustomErrorA.new if tries < 4
+        raise CustomErrorA.new if tries < 3
       end
-      assert_equal 4, tries
-      assert_equal 3, exception_handler_run_times
     end
 
     should "not sleep if Retries.sleep_enabled is false" do


### PR DESCRIPTION
Pass the total time waited to the handler.  This is to facilitate, for example,
bumping a stat or emitting a warning when delays exceed a threshold.

Includes test, and README change.
