### PR TITLE
Concise-ification has broken default errors

### DIFF
--- a/lib/retries.rb
+++ b/lib/retries.rb
@@ -35,7 +35,7 @@ module Kernel
       raise "#{options_error_string} :base_sleep_seconds cannot be greater than :max_sleep_seconds."
     end
     handler = options[:handler]
-    exception_types_to_rescue = Array(options[:rescue]) || [StandardError]
+    exception_types_to_rescue = Array(options[:rescue] || StandardError)
     raise "#{options_error_string} with_retries must be passed a block" unless block_given?
 
     # Let's do this thing


### PR DESCRIPTION
There is a bug in the default error lookup:

```
exception_types_to_rescue = Array(options[:rescue]) || [StandardError]
```

caused by this commit: https://github.com/ooyala/retries/commit/4447c4c988667b6c9c84a34d8f87157b3123adbf

When no rescue option is supplied, it will never catch any error at all, since:

```
 Array(nil) || [StandardError]   # => [], not [StandardError] as hoped!
```

Resolution: 

1) Put the nil check in the Array creator
2) Open beer

Cheers!
