### PR TITLE
Add license to gemspec

### DIFF
--- a/retries.gemspec
+++ b/retries.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{Retries is a gem for retrying blocks with randomized exponential backoff.}
   gem.summary       = %q{Retries is a gem for retrying blocks with randomized exponential backoff.}
   gem.homepage      = "https://github.com/ooyala/retries"
+  gem.licenses      = ["MIT"]
 
   gem.files         = ["lib/retries.rb"]
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Hi! This adds the license identifier to the gemspec. This is handy if you are using a license validator like [Papers](https://rubygems.org/gems/papers).